### PR TITLE
"手合割"ヘッダーが重複する問題を修正

### DIFF
--- a/lib/jkf/converter/kif.rb
+++ b/lib/jkf/converter/kif.rb
@@ -8,6 +8,7 @@ module Jkf::Converter
     def convert_root(jkf)
       reset!
       setup_players!(jkf)
+      jkf = normalize_handicap(jkf)
 
       result = ""
       result += convert_header(jkf["header"]) if jkf["header"]
@@ -113,6 +114,13 @@ module Jkf::Converter
 
     def pos2str(pos)
       "%d%d" % [pos["x"], pos["y"]]
+    end
+
+    def normalize_handicap(jkf)
+      if jkf["initial"] && jkf["initial"]["preset"] && jkf["header"]
+        jkf["header"].delete("手合割")
+      end
+      jkf
     end
   end
 end

--- a/spec/jkf/converter/kif_spec.rb
+++ b/spec/jkf/converter/kif_spec.rb
@@ -24,4 +24,27 @@ describe Jkf::Converter::Kif do
   fixtures(:kif).each do |fixture|
     it_behaves_like :parse_file, fixture
   end
+
+  describe "handicap" do
+    subject {
+      <<-KIF
+手合割：十枚落ち
+手数----指手---------消費時間--
+   1 投了         
+まで0手で後手の勝ち
+      KIF
+    }
+
+    let(:handicap_hash) {
+      {
+        "header" => { "手合割" => "十枚落ち" },
+        "moves" => [{}, { "special" => "TORYO" }],
+        "initial" => { "preset" => "10" }
+      }
+    }
+
+    it "should be convert" do
+      is_expected.to eq kif_converter.convert(handicap_hash)
+    end
+  end
 end


### PR DESCRIPTION
"手合割"ヘッダーがあるkifファイルをparseしてconvertした時に"手合割"が重複する問題を修正しました。

ref: #52 