### PR TITLE
手合割のヘッダーが２つ出ないように修正

### DIFF
--- a/lib/jkf/converter/kif.rb
+++ b/lib/jkf/converter/kif.rb
@@ -10,7 +10,7 @@ module Jkf::Converter
       setup_players!(jkf)
 
       result = ""
-      result += convert_header(jkf["header"]) if jkf["header"]
+      result += convert_header(jkf["header"], jkf) if jkf["header"]
       result += convert_initial(jkf["initial"]) if jkf["initial"]
       result += @header2.join
       result += "手数----指手---------消費時間--\n"
@@ -23,7 +23,7 @@ module Jkf::Converter
       result
     end
 
-    def convert_header(header)
+    def convert_header(header, jkf)
       header.map do |(key, value)|
         result = "#{key}：#{value}\n"
         if key =~ /\A[先後上下]手\Z/
@@ -32,6 +32,8 @@ module Jkf::Converter
           else
             @header2 << result
           end
+          nil
+        elsif key == "手合割" && jkf["initial"] && jkf["initial"]["preset"] && value == preset2str(jkf["initial"]["preset"])
           nil
         else
           result

--- a/spec/jkf/converter/kif_spec.rb
+++ b/spec/jkf/converter/kif_spec.rb
@@ -24,4 +24,27 @@ describe Jkf::Converter::Kif do
   fixtures(:kif).each do |fixture|
     it_behaves_like :parse_file, fixture
   end
+
+  describe "handicap" do
+    subject {
+      <<-KIF
+手合割：十枚落ち
+手数----指手---------消費時間--
+   1 投了         
+まで0手で後手の勝ち
+      KIF
+    }
+
+    let(:handicap_hash) {
+      {
+        "header"  => { "手合割" => "十枚落ち" },
+        "moves"   => [{}, { "special" => "TORYO" }],
+        "initial" => { "preset" => "10" }
+      }
+    }
+
+    it "should be convert" do
+      is_expected.to eq kif_converter.convert(handicap_hash)
+    end
+  end
 end


### PR DESCRIPTION
手合割のヘッダーとpresetの両方がある場合、同じヘッダーが２つ出てしまう問題を修正しました。

ref: #53 