### PR TITLE
fixed method names on README{,.en}.md

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -46,9 +46,9 @@ jkf = csa_parser.parse(csa_str) #=> Hash
 ```
 
 ```ruby
-kif = kif_converter.parse(jkf) #=> String
-ki2 = ki2_converter.parse(jkf) #=> String
-csa = csa_converter.parse(jkf) #=> String
+kif = kif_converter.convert(jkf) #=> String
+ki2 = ki2_converter.convert(jkf) #=> String
+csa = csa_converter.convert(jkf) #=> String
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ jkf = csa_parser.parse(csa_str) #=> Hash
 ```
 
 ```ruby
-kif = kif_converter.parse(jkf) #=> String
-ki2 = ki2_converter.parse(jkf) #=> String
-csa = csa_converter.parse(jkf) #=> String
+kif = kif_converter.convert(jkf) #=> String
+ki2 = ki2_converter.convert(jkf) #=> String
+csa = csa_converter.convert(jkf) #=> String
 ```
 
 ## Contributing


### PR DESCRIPTION
Fixed method names on `README{,.en}.md`.

[Readme usage section](https://github.com/iyuuya/jkf/blob/develop/README.en.md#usage) says following, but `Jkf::Converter::Kif` class doesn't have `#parse`. Perhaps `parse` is `convert` typo.

```ruby
kif_converter = Jkf::Converter::Kif.new

# `jkf` is json-kifu-format hash
kif = kif_converter.parse(jkf) #=> String
```