### PR TITLE
change to use simplecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
 end
 
 group :test do
-  gem "codeclimate-test-reporter", require: nil
   gem "rspec", "~> 3.0", require: false
   gem "guard-rspec", require: false
+  gem "simplecov", require: false
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,6 @@
-require "codeclimate-test-reporter"
-SimpleCov.start do
-  add_filter "/vendor"
-  add_filter ".bundle"
+require "simplecov"
 
-  formatter SimpleCov::Formatter::MultiFormatter.new(
-    [
-      SimpleCov::Formatter::HTMLFormatter,
-      CodeClimate::TestReporter::Formatter
-    ]
-  )
-end
+SimpleCov.start
 
 require "kconv"
 require "pry"


### PR DESCRIPTION
... instead of deprecated codeclimate-test-reporter

This fixes an error while running coverage task, which occurs with: `ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-darwin21]`

Error summary:

> ```text
> Coverage report generated for RSpec to /Users/gemmaro/repos/jkf/coverage. 2269 / 2438 LOC (93.07%) covered.
> Formatter CodeClimate::TestReporter::Formatter failed with NoMethodError: undefined method `map' for #<SimpleCov::Result: ...
> ...
>
>         simplecov_results = results.map do |command_name, data|
>                                    ^^^^
> Did you mean?  tap (/Users/gemmaro/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/codeclimate-test-reporter-1.0.9/lib/code_climate/test_reporter/formatter.rb:16:in `format')
> ```